### PR TITLE
Magika 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/magika-{{ version }}.tar.gz
   sha256: e3dd22c73936630b1cd79d0f412d6d9a53dc99ba5e3709b1ac53f56bc998e635
-  skipe: true  #[py<38]
+  skip: true  #[py<38]
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,25 +8,30 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/magika-{{ version }}.tar.gz
   sha256: e3dd22c73936630b1cd79d0f412d6d9a53dc99ba5e3709b1ac53f56bc998e635
+  skipe: true  #[py<38]
 
 build:
   entry_points:
     - magika-python-client = magika.cli.magika_client:main
     - magika = magika.cli.magika_rust_client_not_found_warning:main
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - click >=8.1.7
-    - onnxruntime >=1.17.0
-    - numpy >=1.24
+    # onnxruntime
+    - onnxruntime >=1.17.0           # [py>39]
+    - onnxruntime >=1.17.0,<1.20.0   # [py<=39]
+    # numpy
+    - numpy >=1.24                   # [py<312]
+    - numpy >=1.26                   # [py>=312]
+    - numpy >=2.1.0                  # [py>=313]
     - python-dotenv >=1.0.1
 
 test:
@@ -39,15 +44,20 @@ test:
     # - magika --help
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   home: https://github.com/google/magika
   dev_url: https://github.com/google/magika/tree/main/python
   doc_url: https://github.com/google/magika
-  summary: A tool to determine the content type of a file with deep-learning
+  summary: A tool to determine the content type of a file with deep-learning.
+  description: |
+    Magika is a tool to determine the content type of a file with deep-learning.
+    It is designed to be used in a pipeline to determine the content type of a file
+    before it is processed by other tools. It is not designed to be used as a standalone
+    tool, but rather as a component in a larger system.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - python
-    - hatchling
+    - maturin >=1.7,<2.0
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - magika-python-client = magika.cli.magika_client:main
     - magika = magika.cli.magika_rust_client_not_found_warning:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 0 
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,12 @@ build:
     - magika-python-client = magika.cli.magika_client:main
     - magika = magika.cli.magika_rust_client_not_found_warning:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0 
+  number: 0
 
 requirements:
   host:
     - python
-    - maturin >=1.7,<2.0
+    - hatchling
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,13 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
   host:
     - python
-    - hatchling
     - pip
+    - hatchling
   run:
     - python
     - click >=8.1.7
@@ -56,7 +59,8 @@ about:
     before it is processed by other tools. It is not designed to be used as a standalone
     tool, but rather as a component in a larger system.
   license: Apache-2.0
-  license_file: LICENSE
+  license_file:
+    - LICENSE
   license_family: Apache
 
 extra:


### PR DESCRIPTION
> ## ☆ Magika v0.6.1 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8025) 
[Upstream](https://github.com/google/magika/tree/python-v0.6.1)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section
